### PR TITLE
Integrating IPinfo for IP metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ docker run --rm --name tor-proxy-rotating -e TORS=3 -e HEADS=2 \
     datawookie/tor-proxy-rotating
 
 # Test SOCKS proxy
-curl --socks5 localhost:5566 http://httpbin.org/ip
+curl --socks5 localhost:5566 https://ipinfo.io/ip
 
 # Test HTTP proxy
-curl --proxy localhost:8888 http://httpbin.org/ip
+curl --proxy localhost:8888 https://ipinfo.io/ip
 
 # Run Chromium through the proxy
 chromium --proxy-server="http://localhost:8118" \

--- a/proxy/tor.py
+++ b/proxy/tor.py
@@ -76,7 +76,7 @@ class Tor(Service):
             #
             try:
                 response = requests.get(
-                    f"http://ip-api.com/json/{ip}",
+                    f"https://ipinfo.io/{ip}/json",
                     proxies=proxies,
                     timeout=WORKING_TIMEOUT,
                 )
@@ -90,11 +90,14 @@ class Tor(Service):
                 log.warning("🚨 Failed to get location.")
 
             if location:
+                # IPinfo returns strings for loc in "lat,lng" format
+                loc_string = location['loc']
+                lat, lon = map(float, loc_string.split(','))
+
                 location = [
                     "",
-                    f"{location['country']:15}",
-                    f"{location['city']:18}",
-                    f"{location['lat']:+6.2f} / {location['lon']:+7.2f}",
+                    f"{location['city']}, {location['country']:15}",
+                    f"{lat:+6.2f} / {lon:+7.2f}",
                 ]
                 location = " | ".join(location)
 


### PR DESCRIPTION
## Description
As discussed in: https://github.com/datawookie/medusa-proxy/issues/7

## ✅ Checks

- [] Adheres to code style
- [] All tests pass
- [] Documentation updated

---

Difference in location payload response:

Existing response:

```
| Japan           | Osaka              | +34.69 / +135.49
```

IPinfo modified response:

```
 | Osaka, JP | 34.6938,135.5011
```

I have included some untested code, if you can verify it that will be great.

You are making a call to get the IP address from `https://api.ipify.org?format=json` and then passing the IP address to `http://ip-api.com/json/{ip}`. This is not necessary. If you call `ipinfo` without passing an IP address, the information returned will be about the IP address.