### PR TITLE
Update version of lyrebird from r1 to r2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.13-alpine
 
 RUN apk add tor haproxy privoxy
 
-RUN wget http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/lyrebird-0.6.1-r1.apk
-RUN apk add --allow-untrusted lyrebird-0.6.1-r1.apk
+RUN wget http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/lyrebird-0.6.1-r2.apk
+RUN apk add --allow-untrusted lyrebird-0.6.1-r2.apk
 
 COPY requirements.txt .
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ USERNAME = datawookie
 IMAGE_VERSION = $(USERNAME)/$(IMAGE):$(VERSION)
 IMAGE_LATEST = $(USERNAME)/$(IMAGE):latest
 
-clean: 
+clean:
 	-@docker rmi -f $(IMAGE_VERSION) $(IMAGE_LATEST) 2>/dev/null
 	-@docker builder prune -af
 


### PR DESCRIPTION
## Changes

- version for the apk in the Dockerfile updated

### Description

```bash
docker build -t datawookie/medusa-proxy .
```
fails because the version of the apk mentioned in the Dockerfile is no longer available.     
A newer version exists: [lyrebird-0.6.1-r2.apk](https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/lyrebird-0.6.1-r2.apk). With the newer version `docker build` is successful.


## ✅ Checks

- [ ] Adheres to code style
- [ ] All tests pass
- [ ] Documentation updated
