### PR TITLE
Combine Docker build commands to optimize image size and enhance build performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,19 @@
-FROM python:3.13-alpine
+FROM docker.io/library/python:3.13-alpine
 
-RUN apk add tor haproxy privoxy
+RUN apk --no-cache --no-progress add haproxy privoxy tor lyrebird=~0.6
 
-RUN wget http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/lyrebird-0.6.1-r2.apk
-RUN apk add --allow-untrusted lyrebird-0.6.1-r2.apk
+WORKDIR /
 
 COPY requirements.txt .
 
 RUN pip3 install -r requirements.txt
 
-WORKDIR /
-
 COPY start.py proxy-list.py config.py /
 COPY proxy/ /proxy
 COPY templates/ /templates
+
 RUN chmod +x *.py
 
-EXPOSE 2090 1080 8888 8800
+EXPOSE 1080 2090 8800 8888
 
 CMD ["./start.py"]


### PR DESCRIPTION
## Description

Merged multiple `RUN` commands into a single layer to reduce image size and improve build performance. Additionally, `lyrebird` is now installed from `community` using the latest `0.6.x` minor version. Using `--no-cache` prevents the caching of the index, which reduces the image size by not storing unnecessary files.

<details>
<summary>Docker Build Output</summary>

```shell
#0 building with "default" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 381B done
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/library/python:3.13-alpine
#2 DONE 5.2s

#3 [internal] load .dockerignore
#3 transferring context: 2B done
#3 DONE 0.0s

#4 [1/9] FROM docker.io/library/python:3.13-alpine@sha256:9ba6d8cbebf0fb6546ae71f2a1c14f6ffd2fdab83af7fa5669734ef30ad48844
#4 CACHED

#5 [internal] load build context
#5 transferring context: 506B done
#5 DONE 0.0s

#6 [2/9] RUN apk --no-cache --no-progress add haproxy privoxy tor lyrebird=~0.6
#6 0.208 fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz
#6 0.525 fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/community/x86_64/APKINDEX.tar.gz
#6 1.026 (1/11) Installing lua5.4-libs (5.4.7-r0)
#6 1.077 (2/11) Installing pcre2 (10.43-r1)
#6 1.141 (3/11) Installing haproxy (3.2.4-r0)
#6 1.185 Executing haproxy-3.2.4-r0.pre-install
#6 1.412 (4/11) Installing lyrebird (0.6.1-r3)
#6 1.815 (5/11) Installing pcre (8.45-r4)
#6 1.854 (6/11) Installing privoxy (3.0.34-r3)
#6 1.888 Executing privoxy-3.0.34-r3.pre-install
#6 1.955 (7/11) Installing libcap2 (2.76-r0)
#6 1.988 (8/11) Installing libevent (2.1.12-r8)
#6 2.038 (9/11) Installing libseccomp (2.6.0-r0)
#6 2.064 (10/11) Installing zstd-libs (1.5.7-r0)
#6 2.121 (11/11) Installing tor (0.4.8.18-r0)
#6 2.148 Executing tor-0.4.8.18-r0.pre-install
#6 2.381 Executing busybox-1.37.0-r18.trigger
#6 2.386 OK: 61 MiB in 40 packages
#6 DONE 2.5s

#7 [3/9] COPY requirements.txt .
#7 DONE 0.0s

#8 [4/9] RUN pip3 install -r requirements.txt
#8 1.969 Collecting Jinja2==3.1.2 (from -r requirements.txt (line 1))
#8 2.051   Downloading Jinja2-3.1.2-py3-none-any.whl.metadata (3.5 kB)
#8 2.189 Collecting pre-commit==3.2.0 (from -r requirements.txt (line 2))
#8 2.221   Downloading pre_commit-3.2.0-py2.py3-none-any.whl.metadata (1.3 kB)
#8 2.283 Collecting PySocks==1.7.1 (from -r requirements.txt (line 3))
#8 2.312   Downloading PySocks-1.7.1-py3-none-any.whl.metadata (13 kB)
#8 2.411 Collecting requests==2.26.0 (from -r requirements.txt (line 4))
#8 2.435   Downloading requests-2.26.0-py2.py3-none-any.whl.metadata (4.8 kB)
#8 2.579 Collecting MarkupSafe>=2.0 (from Jinja2==3.1.2->-r requirements.txt (line 1))
#8 2.619   Downloading MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl.metadata (4.0 kB)
#8 2.697 Collecting cfgv>=2.0.0 (from pre-commit==3.2.0->-r requirements.txt (line 2))
#8 2.724   Downloading cfgv-3.4.0-py2.py3-none-any.whl.metadata (8.5 kB)
#8 2.823 Collecting identify>=1.0.0 (from pre-commit==3.2.0->-r requirements.txt (line 2))
#8 2.849   Downloading identify-2.6.14-py2.py3-none-any.whl.metadata (4.4 kB)
#8 2.924 Collecting nodeenv>=0.11.1 (from pre-commit==3.2.0->-r requirements.txt (line 2))
#8 2.944   Downloading nodeenv-1.9.1-py2.py3-none-any.whl.metadata (21 kB)
#8 3.054 Collecting pyyaml>=5.1 (from pre-commit==3.2.0->-r requirements.txt (line 2))
#8 3.073   Downloading PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl.metadata (2.1 kB)
#8 3.159 Collecting virtualenv>=20.10.0 (from pre-commit==3.2.0->-r requirements.txt (line 2))
#8 3.180   Downloading virtualenv-20.34.0-py3-none-any.whl.metadata (4.6 kB)
#8 3.245 Collecting urllib3<1.27,>=1.21.1 (from requests==2.26.0->-r requirements.txt (line 4))
#8 3.269   Downloading urllib3-1.26.20-py2.py3-none-any.whl.metadata (50 kB)
#8 3.441 Collecting certifi>=2017.4.17 (from requests==2.26.0->-r requirements.txt (line 4))
#8 3.465   Downloading certifi-2025.8.3-py3-none-any.whl.metadata (2.4 kB)
#8 3.652 Collecting charset-normalizer~=2.0.0 (from requests==2.26.0->-r requirements.txt (line 4))
#8 3.674   Downloading charset_normalizer-2.0.12-py3-none-any.whl.metadata (11 kB)
#8 3.758 Collecting idna<4,>=2.5 (from requests==2.26.0->-r requirements.txt (line 4))
#8 3.792   Downloading idna-3.10-py3-none-any.whl.metadata (10 kB)
#8 3.960 Collecting distlib<1,>=0.3.7 (from virtualenv>=20.10.0->pre-commit==3.2.0->-r requirements.txt (line 2))
#8 3.994   Downloading distlib-0.4.0-py2.py3-none-any.whl.metadata (5.2 kB)
#8 4.076 Collecting filelock<4,>=3.12.2 (from virtualenv>=20.10.0->pre-commit==3.2.0->-r requirements.txt (line 2))
#8 4.102   Downloading filelock-3.19.1-py3-none-any.whl.metadata (2.1 kB)
#8 4.159 Collecting platformdirs<5,>=3.9.1 (from virtualenv>=20.10.0->pre-commit==3.2.0->-r requirements.txt (line 2))
#8 4.179   Downloading platformdirs-4.4.0-py3-none-any.whl.metadata (12 kB)
#8 4.217 Downloading Jinja2-3.1.2-py3-none-any.whl (133 kB)
#8 4.267 Downloading pre_commit-3.2.0-py2.py3-none-any.whl (202 kB)
#8 4.355 Downloading PySocks-1.7.1-py3-none-any.whl (16 kB)
#8 4.391 Downloading requests-2.26.0-py2.py3-none-any.whl (62 kB)
#8 4.435 Downloading charset_normalizer-2.0.12-py3-none-any.whl (39 kB)
#8 4.464 Downloading idna-3.10-py3-none-any.whl (70 kB)
#8 4.494 Downloading urllib3-1.26.20-py2.py3-none-any.whl (144 kB)
#8 4.539 Downloading certifi-2025.8.3-py3-none-any.whl (161 kB)
#8 4.595 Downloading cfgv-3.4.0-py2.py3-none-any.whl (7.2 kB)
#8 4.625 Downloading identify-2.6.14-py2.py3-none-any.whl (99 kB)
#8 4.668 Downloading MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl (23 kB)
#8 4.704 Downloading nodeenv-1.9.1-py2.py3-none-any.whl (22 kB)
#8 4.742 Downloading PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl (751 kB)
#8 4.875    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 751.6/751.6 kB 5.6 MB/s  0:00:00
#8 4.899 Downloading virtualenv-20.34.0-py3-none-any.whl (6.0 MB)
#8 5.463    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.0/6.0 MB 10.9 MB/s  0:00:00
#8 5.496 Downloading distlib-0.4.0-py2.py3-none-any.whl (469 kB)
#8 5.544 Downloading filelock-3.19.1-py3-none-any.whl (15 kB)
#8 5.574 Downloading platformdirs-4.4.0-py3-none-any.whl (18 kB)
#8 5.678 Installing collected packages: distlib, urllib3, pyyaml, PySocks, platformdirs, nodeenv, MarkupSafe, idna, identify, filelock, charset-normalizer, cfgv, certifi, virtualenv, requests, Jinja2, pre-commit
#8 6.617 
#8 6.621 Successfully installed Jinja2-3.1.2 MarkupSafe-3.0.2 PySocks-1.7.1 certifi-2025.8.3 cfgv-3.4.0 charset-normalizer-2.0.12 distlib-0.4.0 filelock-3.19.1 identify-2.6.14 idna-3.10 nodeenv-1.9.1 platformdirs-4.4.0 pre-commit-3.2.0 pyyaml-6.0.2 requests-2.26.0 urllib3-1.26.20 virtualenv-20.34.0
#8 6.621 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
#8 DONE 6.9s

#9 [5/9] COPY start.py proxy-list.py config.py /
#9 DONE 0.0s

#10 [6/9] COPY proxy/ /proxy
#10 DONE 0.0s

#11 [7/9] COPY templates/ /templates
#11 DONE 0.0s

#12 [8/9] RUN chmod +x *.py
#12 DONE 0.2s

#13 exporting to image
#13 exporting layers
#13 exporting layers 0.9s done
#13 writing image sha256:d766f94458b655dacd81a2c7716d491416c2900083b55a045541d83ddb136393 done
#13 naming to docker.io/datawookie/medusa-proxy:latest done
#13 DONE 0.9s
```
</details>

## ✅ Checks

- [x] Adheres to code style
- [x] All tests pass
- [x] Documentation updated
