### PR TITLE
Improve Dockerfile build efficiency and cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
 FROM docker.io/library/python:3.13-alpine
 
-RUN apk --no-cache --no-progress add haproxy privoxy tor lyrebird=~0.6
-
 WORKDIR /
 
 COPY requirements.txt .
 
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir --requirement requirements.txt; \
+  rm requirements.txt
 
-COPY start.py proxy-list.py config.py /
 COPY proxy/ /proxy
 COPY templates/ /templates
+COPY config.py proxy-list.py start.py /
 
-RUN chmod +x *.py
+RUN apk --no-cache --no-progress add haproxy lyrebird=~0.6 privoxy tor; \
+  chmod +x config.py proxy-list.py start.py
 
 EXPOSE 1080 2090 8800 8888
 
-CMD ["./start.py"]
+CMD ["/start.py"]


### PR DESCRIPTION
## Description

- Combine package installation and file permission steps into a single `RUN` to reduce image layers
- Use `pip` without caching and install requirements before copying application files to improve layer caching
- Make scripts executable and run the start script by absolute path
- Remove unnecessary build artifacts (`requirements.txt`) to further slim the image

Closes #18 

## ✅ Checks

- [X] Adheres to code style
- [X] All tests pass
- [X] Documentation updated
