### PR TITLE
Introduce environment variable to set proxy check and rotation interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ Privoxy exposes an HTTP proxy.
 
 ## Environment Variables
 
-- `HEADS` — Number of Privoxy instances (default: 1).
-- `TORS` — Number of Tor instances (default: 5).
-- `HAPROXY_LOGIN` — Username for HAProxy (default: "admin").
-- `HAPROXY_PASSWORD` — Password for HAProxy (default: "admin").
-- `TOR_BRIDGES` - Bridge multiline string with bridges records (default : "").
-- `TOR_EXIT_NODES` - Tor exit nodes config (default : "" , for example `TOR_EXIT_NODES=ru` or `TOR_EXIT_NODES=ru,en`).
+- `HAPROXY_LOGIN` — Username for HAProxy (default: `admin`).
+- `HAPROXY_PASSWORD` — Password for HAProxy (default: `admin`).
+- `HEADS` — Number of Privoxy instances (default: `1`).
+- `PROXY_CHECK_INTERVAL` — Represents the interval (in minutes) at which the proxy checks/rotations are performed (default: `15`).
+- `TORS` — Number of Tor instances (default: `5`).
+- `TOR_BRIDGES` — Bridge multiline string with bridges records (default: `""`).
+- `TOR_EXIT_NODES` — Tor exit nodes config (default: `""`, for example `TOR_EXIT_NODES=ru` or `TOR_EXIT_NODES=ru,en`).
 
 ## Tor Bridges
 

--- a/start.py
+++ b/start.py
@@ -12,12 +12,11 @@ from proxy import log, Privoxy
 PROXY_LIST_TXT = "proxy-list.txt"
 PROXY_LIST_PY = "proxy-list.py"
 
-TORS = int(os.environ.get("TORS", 5))
 HEADS = int(os.environ.get("HEADS", 1))
-
+PROXY_CHECK_INTERVAL = int(os.environ.get("PROXY_CHECK_INTERVAL", 15)) # In minutes
+TORS = int(os.environ.get("TORS", 5))
 
 def get_versions():
-
     for cmd in ["privoxy --version", "haproxy -v", "tor --version"]:
         result = subprocess.run(cmd.split(), stdout=subprocess.PIPE)
 
@@ -27,7 +26,6 @@ def get_versions():
         version = re.sub(r"\.$", "", version)
 
         log.info("- " + version)
-
 
 def main():
     log.info("========================================")
@@ -57,13 +55,10 @@ def main():
                     if not proxy.working:
                         log.warning("Restarting.")
                         proxy.restart()
-
             log.info("Sleeping.")
-            time.sleep(60)
-
+            time.sleep(PROXY_CHECK_INTERVAL * 60)
         for http in privoxy:
             http.cycle()
-
 
 try:
     main()


### PR DESCRIPTION
## Description

Introduces an environment variable, `PROXY_CHECK_INTERVAL`, to configure the duration between proxy checks/rotations.

Default value is set to 15 minutes.

Resolves #21 

## ✅ Checks

- [X] Adheres to code style
- [X] All tests pass
- [X] Documentation updated
