### PR TITLE
Run proxy list server via Python interpreter

### DIFF
--- a/start.py
+++ b/start.py
@@ -75,7 +75,7 @@ def main():
     log.info("Done.")
 
     log.info("Serving proxy list.")
-    os.spawnl(os.P_NOWAIT, os.curdir + os.sep + PROXY_LIST_PY, PROXY_LIST_PY)
+    os.spawnl(os.P_NOWAIT, sys.executable, sys.executable, PROXY_LIST_PY)
 
     while True:
         for i in range(HEADS):


### PR DESCRIPTION
## Description

Fixes startup of `proxy-list.py` inside the container by launching it via the active Python interpreter instead of executing the script file directly.

Previously, `start.py` executed `proxy-list.py` as a standalone file. In environments where the script used Windows `CRLF` line endings, this could break the shebang handling in Linux containers and cause a `No such file or directory` error.

This change makes the startup more robust by invoking the script through `sys.executable`.

## ✅ Checks

- [x] Adheres to code style
- [ ] All tests pass
- [ ] Documentation updated
